### PR TITLE
Better behaviour when FILE in `zappa FILE` does not exist

### DIFF
--- a/bin/zappa.coffee
+++ b/bin/zappa.coffee
@@ -69,11 +69,18 @@ puts zappa.version if options.version
 
 if args.length > 0
   file = args[0]
-  if options.compile then compile file
-  else
-    if options.watch
-      remove_watch_option()
-      spawn_child()
-      watch file
+  
+  path.exists file, (exists) ->
+    if !exists
+      console.log "#{file} not found."
+      process.exit -1
+    
+    if options.compile
+      compile file
     else
-      zappa.run_file file, options
+      if options.watch
+        remove_watch_option()
+        spawn_child()
+        watch file
+      else
+        zappa.run_file file, options


### PR DESCRIPTION
I just noticed this when writing up the issue on the zappa executable's behaviour - just a better erorr message - nothing too critical.

Tests would be worth their weight in gold. The testing of examples can be automated with something like [soda](http://sodajs.com/).

I might take a stab at that now...
