### PR TITLE
Resolve included *.coffee file paths when watching application file.

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -52,7 +52,7 @@ spawn_child = ->
     data = String(data)
     if data.match /^Included file \".*\.coffee\"/
       included = data.match(/^Included file \"(.*\.coffee)\"/)[1]
-      watch path.join(path.dirname(file), included) unless included in watching
+      watch path.resolve included unless included in watching
       watching.push included
     puts data
   child.stderr.on 'data', (data) -> puts String(data)


### PR DESCRIPTION
Fixes #41, watch included *.coffee files that may or may not be next to the main application file in the project structure.

It looks like the current `watch` code assumes that `include`ed files are in the same directory as the main application file.  I don't happen to have my project structured that way, and those `*.coffee` files are not being watched because their paths are not being resolved properly.  Using a [`resolve`](http://nodejs.org/docs/v0.4.8/api/all.html#path.resolve) call takes care of that.
