### PR TITLE
Feature: allowing include to accept directories

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -59,9 +59,9 @@ select = (names, scopes) ->
   _.union (names[i] for i in scopes.split ' + ')
 
 tempfile_regexes = [
-  /*~/
-  /*.swp/
-  /.DS_Store/
+  /~$/
+  /\.swp$/
+  /\.DS_Store$/
 ]
 
 is_tempfile = (name) ->
@@ -317,7 +317,7 @@ zappa.app = ->
     fs.stat name, (err, stats) ->
       if stats?.isDirectory()
         for file in fs.readdirSync(name) when not is_tempfile file
-          root_locals.include_file name + '/' + file
+          root_locals.include name + '/' + file
       else
         root_locals.include_file name
 


### PR DESCRIPTION
I'm currently getting a strange error and am hoping you might know what it is?

```
$ cat test.coffee
require('zappa/src/zappa') ->  
  include 'db'
$ ls db
model.coffee 
setup.coffee
$ coffee test.coffee
Express server listening on port 3000 in development mode
Zappa 0.2.0edge orchestrating the show

undefined:2
 if (this[i] === item) return i;  } return -1; };return (undefined).apply(cont
                                                                    ^
TypeError: Cannot call method 'apply' of undefined
    at anonymous (eval at <anonymous> (/Users/me/code/orgist/node_modules/zappa/src/zappa.coffee:35:12))
    at Object.include_file (/Users/me/code/orgist/node_modules/zappa/src/zappa.coffee:457:14)
    at /Users/me/code/orgist/node_modules/zappa/src/zappa.coffee:473:30
```
