### PR TITLE
sammy url in Cakefile is non-SSL

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -14,8 +14,8 @@ task 'docs', ->
   run 'docco src/*.coffee'
   
 task 'vendor', ->
-  run 'mkdir -p vendor && cd vendor && curl -OL http://code.jquery.com/jquery-1.6.4.min.js', ->
-    run 'cd vendor && curl -OL http://raw.github.com/quirkey/sammy/v0.7.0/lib/min/sammy-0.7.0.min.js', ->
+  run 'mkdir -p vendor && cd vendor && curl -OLk https://code.jquery.com/jquery-1.6.4.min.js', ->
+    run 'cd vendor && curl -OL https://raw.github.com/quirkey/sammy/v0.7.0/lib/min/sammy-0.7.0.min.js', ->
       run 'head -n 1 vendor/jquery*', ->
         run 'head -n 3 vendor/sammy*'
         

--- a/Cakefile
+++ b/Cakefile
@@ -14,7 +14,7 @@ task 'docs', ->
   run 'docco src/*.coffee'
   
 task 'vendor', ->
-  run 'mkdir -p vendor && cd vendor && curl -OLk https://code.jquery.com/jquery-1.6.4.min.js', ->
+  run 'mkdir -p vendor && cd vendor && curl -OL http://code.jquery.com/jquery-1.6.4.min.js', ->
     run 'cd vendor && curl -OL https://raw.github.com/quirkey/sammy/v0.7.0/lib/min/sammy-0.7.0.min.js', ->
       run 'head -n 1 vendor/jquery*', ->
         run 'head -n 3 vendor/sammy*'


### PR DESCRIPTION
The github URLs are now all `https` - whereas the URL for `sammy.js` in `Cakefile` is still `http`.  I _think_ this is the reason it's failing so often.

Not sure why curl isn't redirecting properly, something to do with github's http response.

I wasn't sure whether just changing the URL was a desirable fix because unless you have your curl setup correctly, it'll fail on the `https` URL if it can't validate against your system CA file.
