### PR TITLE
Share the Express session with Socket.IO, if it exists

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -103,9 +103,25 @@ zappa.app = (func) ->
   ws_handlers = {}
   helpers = {}
   postrenders = {}
+  session_key = 'connect.sid'
   
   app = context.app = express.createServer()
   io = context.io = socketio.listen(app)
+
+  # Let Socket.IO know which Express session this socket is associated with
+  # Session variables can't be accessed by Socket.IO, but it allows Express
+  # actions to emit to all sockets associated with this session.
+  io.set 'authorization', (data, accept) ->
+    cookieParser = express.cookieParser()
+    cookieParser data, null, (error) ->
+      if error
+        log "Problem extracting sessionId: ", error
+      else if not data.cookies[session_key]?
+        log "No session cookie found."
+      else
+        data.sessionId = data.cookies[session_key]
+      # Always authorize, even without a cookie
+      accept(null, true);
 
   # Reference to the zappa client, the value will be set later.
   client = null
@@ -194,6 +210,9 @@ zappa.app = (func) ->
     wrappers =
       static: (p = path.join(context.root, '/public')) ->
         express.static(p)
+      session: (options = {}) ->
+        session_key = options['key'] ? session_key
+        express.session(options)
 
     use = (name, arg = null) ->
       if wrappers[name]
@@ -245,6 +264,10 @@ zappa.app = (func) ->
           next: next
           send: -> res.send.apply res, arguments
           redirect: -> res.redirect.apply res, arguments
+          emit: ->
+            if req.session?
+              set = io.sockets.in(req.session.id)
+              set.emit.apply set, arguments if set?
           render: ->
             if typeof arguments[0] isnt 'object'
               render.apply @, arguments
@@ -300,6 +323,11 @@ zappa.app = (func) ->
   
   # Register socket.io handlers.
   io.sockets.on 'connection', (socket) ->
+    # Make this socket join the session's room
+    # See http://www.danielbaulig.de/socket-ioexpress/
+    if socket.handshake.sessionId
+      socket.join(socket.handshake.sessionId)
+
     c = {}
     
     build_ctx = ->


### PR DESCRIPTION
Based on the following article. Read the comments, too.
http://www.danielbaulig.de/socket-ioexpress/

This lets regular requests that hit Express actions emit messages back to clients over all socket.io connections they've established (with the same Express session id).

This is great for handling some work asynchronously in Node (like file parsing) by sending back a response immediately, then sending updates to the browser as events occur during your long task (like 'finished parsing', or 'error parsing').
