### PR TITLE
Fix problems referencing partial 'global/nav' from layout

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -74,7 +74,12 @@ express.View.prototype.__defineGetter__ 'exists', ->
     fs.statSync(p)
     return true
   catch err
-    return false
+    p = @path
+    try
+      fs.statSync(p)
+      return true
+    catch err
+      return false
 
 express.View.prototype.__defineGetter__ 'contents', ->
   # Path given by zappa: /path/to/appid/foo.bar.
@@ -90,7 +95,11 @@ express.View.prototype.__defineGetter__ 'contents', ->
 
   # Try /path/to/foo.bar in filesystem (normal express behaviour).
   p = @path.replace id + '/', ''
-  fs.readFileSync p, 'utf8'
+  try
+    fs.readFileSync p, 'utf8'
+  catch err
+    p = @path
+    fs.readFileSync p, 'utf8'
 
 # Takes in a function and builds express/socket.io apps based on the rules contained in it.
 zappa.app = (func) ->
@@ -264,6 +273,16 @@ zappa.app = (func) ->
         
           if app.settings['databag']
             args[1].params = data
+
+          # Don't change layout: false
+          unless args[1].layout is false
+            # Use the default layout if one isn't given, or layout: true
+            if args[1].layout is true or not args[1].layout?
+              args[1].layout = 'layout'
+
+            # Don't add id if it's there already
+            if args[1].layout.split('/')[0] is not context.id
+              args[1].layout = context.id + '/' + args[1].layout
 
           if args[1].postrender?
             # Apply postrender before sending response.


### PR DESCRIPTION
Layout didn't get the app id appended to it, so referencing a partial
with a name 'global/nav' resulted in the monkeypatching expecting that
the app id was 'global'. Additionally, even if the monkeypatched vesion
received a valid raw path, the raw version was never attempted.

This is fixed in two ways:
- First, we add the app id to the layout sent to any 'render' call
  except for `layout: false`
- Second, we add a fallback to the monkeypatching where we simply try
  what express would do with the raw path parameter

The tests show both problems.

Of note is the fact that the problem can be fixed by #2 alone, but then
it always checks the filesystem twice. The change for #1 avoids that.
