### PR TITLE
Express middleware object support

### DIFF
--- a/src/zappa.coffee
+++ b/src/zappa.coffee
@@ -220,7 +220,11 @@ zappa.app = (func) ->
       switch typeof a
         when 'function' then app.use a
         when 'string' then use a
-        when 'object' then use k, v for k, v of a
+        when 'object'
+          if a.stack? or a.route?
+            app.use a
+          else
+            use k, v for k, v of a
     
   context.configure = (p) ->
     if typeof p is 'function' then app.configure p


### PR DESCRIPTION
I was using [everyauth](https://github.com/bnoguchi/everyauth) lib as middleware, and it doesn't work with Zappa, when passing express middleware object as arguments of context.use.
